### PR TITLE
chore: enforce Gemini review, generalize agent workflows, standardize labels

### DIFF
--- a/.github/workflows/ai-review-required.yml
+++ b/.github/workflows/ai-review-required.yml
@@ -1,0 +1,29 @@
+name: Require Gemini AI Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-ai-review:
+    name: Check for 'ai-review' label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure Gemini review label present
+        id: ensure-label
+        run: |
+          NUMBER='${{ github.event.pull_request.number }}'
+          LABELS=$(gh --repo "${{ github.repository }}" pr view "$NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+          echo "Labels: $LABELS"
+          if echo "$LABELS" | grep -q '\bai-review\b'; then
+            echo "Gemini AI review label present."
+            exit 0
+          fi
+          echo "Missing required 'ai-review' label. Trigger a Gemini review (e.g., comment /gemini review) or wait for the app to complete."
+          exit 1
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/assign-rfc-issues-to-agent.yml
+++ b/.github/workflows/assign-rfc-issues-to-agent.yml
@@ -1,0 +1,103 @@
+name: Assign RFC Issues to Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: 'Comma-separated issue numbers, or "all" for all open RFC implementation issues'
+        required: true
+        default: 'all'
+        type: string
+      assignee_login:
+        description: 'Login to assign (optional). If empty, only labels/comments are applied.'
+        required: false
+        type: string
+      labels:
+        description: 'Comma-separated labels to add (optional), e.g., in-progress,agent-assigned'
+        required: false
+        type: string
+      add_comment:
+        description: 'Add a guidance comment to each issue'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine target issues
+        id: issues
+        run: |
+          INPUTS='${{ github.event.inputs.issue_numbers }}'
+          if [ "$INPUTS" = "all" ]; then
+            IDS=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --json number --jq '.[].number' | tr '\n' ',')
+          else
+            IDS=$(echo "$INPUTS" | tr -d ' ')
+          fi
+          IDS=${IDS%,}
+          if [ -z "$IDS" ]; then
+            echo "❌ No target issues found."
+            exit 1
+          fi
+          echo "ids=$IDS" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Assign/label/comment issues
+        run: |
+          IFS=',' read -ra ARR <<< "${{ steps.issues.outputs.ids }}"
+          ASSIGNEE='${{ github.event.inputs.assignee_login }}'
+          LABELS='${{ github.event.inputs.labels }}'
+          ADD_COMMENT='${{ github.event.inputs.add_comment }}'
+
+          for num in "${ARR[@]}"; do
+            num=$(echo "$num" | xargs)
+            if [ -z "$num" ]; then continue; fi
+            echo "Processing issue #$num"
+
+            if [ -n "$ASSIGNEE" ]; then
+              echo " - Assigning @$ASSIGNEE"
+              gh --repo "${{ github.repository }}" issue edit "$num" --add-assignee "$ASSIGNEE" || echo "Assignment may have failed or already set"
+            fi
+
+            if [ -n "$LABELS" ]; then
+              # convert comma list to repeated --add-label flags
+              LABEL_FLAGS=()
+              IFS=',' read -ra LARR <<< "$LABELS"
+              for l in "${LARR[@]}"; do
+                l=$(echo "$l" | xargs)
+                [ -n "$l" ] && LABEL_FLAGS+=(--add-label "$l")
+              done
+              if [ ${#LABEL_FLAGS[@]} -gt 0 ]; then
+                echo " - Adding labels: $LABELS"
+                gh --repo "${{ github.repository }}" issue edit "$num" "${LABEL_FLAGS[@]}" || true
+              fi
+            fi
+
+            if [ "$ADD_COMMENT" = "true" ]; then
+              TITLE=$(gh --repo "${{ github.repository }}" issue view "$num" --json title --jq .title)
+              RFC=$(echo "$TITLE" | grep -o 'RFC[0-9]\+' || true)
+              read -r -d '' COMMENT << 'EOF'
+Guidance for implementing this RFC:
+
+- Follow the RFC acceptance criteria and update checkboxes as you progress.
+- Create a feature branch per repo conventions.
+- Write and run tests locally; aim for meaningful coverage.
+- Open a draft PR early; request Gemini review by commenting `/gemini review`.
+- Keep commits small and descriptive.
+
+Refer to AI-REVIEWERS.md for Gemini Code Assist usage and labels.
+EOF
+              gh --repo "${{ github.repository }}" issue comment "$num" --body "$COMMENT" || true
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/assign-rfc-issues-to-copilot.yml
+++ b/.github/workflows/assign-rfc-issues-to-copilot.yml
@@ -1,76 +1,18 @@
-name: Assign RFC Issues to Copilot
+name: DEPRECATED - Assign RFC Issues to Copilot
 
 on:
   workflow_dispatch:
-    inputs:
-      issue_numbers:
-        description: 'Comma-separated issue numbers, or "all" for all open RFC issues'
-        required: true
-        default: 'all'
-        type: string
-      add_comment:
-        description: 'Add an implementation instruction comment to each issue'
-        required: true
-        default: true
-        type: boolean
 
 permissions:
-  issues: write
   contents: read
 
 jobs:
-  assign:
+  deprecate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve Copilot assignee login
-        id: resolve
+      - name: Deprecation notice
         run: |
-          echo "Resolving Copilot assignee login..."
-          CANDIDATE=$(gh api repos/${{ github.repository }}/assignees --jq '.[] | select((.login|ascii_downcase)=="copilot" or (.login|test("copilot"; "i"))) | .login' | head -n1)
-          if [ -z "$CANDIDATE" ]; then
-            echo "❌ Could not find a Copilot assignee for this repository. Ensure Copilot Coding Agent is enabled and has access."
-            exit 1
-          fi
-          echo "copilot_login=$CANDIDATE" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Determine target issues
-        id: issues
-        run: |
-          INPUTS="${{ github.event.inputs.issue_numbers }}"
-          if [ "$INPUTS" = "all" ]; then
-            IDS=$(gh issue list --state open --label rfc-implementation --json number --jq '.[].number' | tr '\n' ',')
-          else
-            IDS=$(echo "$INPUTS" | tr -d ' ')
-          fi
-          IDS=${IDS%,}
-          if [ -z "$IDS" ]; then
-            echo "❌ No target issues found."
-            exit 1
-          fi
-          echo "ids=$IDS" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Assign issues to Copilot and optionally comment
-        run: |
-          IFS=',' read -ra ARR <<< "${{ steps.issues.outputs.ids }}"
-          for num in "${ARR[@]}"; do
-            num=$(echo "$num" | xargs)
-            if [ -z "$num" ]; then continue; fi
-            echo "Assigning issue #$num to ${{ steps.resolve.outputs.copilot_login }}"
-            gh issue edit "$num" --add-assignee "${{ steps.resolve.outputs.copilot_login }}" || echo "Assignment may have failed or already set"
-
-            if [ "${{ github.event.inputs.add_comment }}" = "true" ]; then
-              TITLE=$(gh issue view "$num" --json title --jq .title)
-              RFC=$(echo "$TITLE" | grep -o 'RFC[0-9]\+' || true)
-              COMMENT="@copilot Please implement this RFC according to its specification.\n\nRequirements:\n- Create a feature branch following repo conventions\n- Implement all acceptance criteria\n- Write comprehensive tests (>80% coverage)\n- Update RFC status through Draft → In Progress → Complete\n- Open a PR when ready"
-              gh issue comment "$num" --body "$COMMENT"
-            fi
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
+          echo "This workflow is deprecated."
+          echo "Use 'Assign RFC Issues to Agent' instead: .github/workflows/assign-rfc-issues-to-agent.yml"
+          echo "It supports custom assignees, labels, and neutral guidance comments."
+          exit 1

--- a/.github/workflows/auto-merge-coordinator.yml
+++ b/.github/workflows/auto-merge-coordinator.yml
@@ -129,6 +129,18 @@ jobs:
           echo "completion_percentage=0" >> $GITHUB_OUTPUT
         fi
         
+    - name: Fetch PR state and labels
+      id: pr-state
+      run: |
+        NUMBER='${{ github.event.pull_request.number }}'
+        MERGEABLE=$(gh --repo "${{ github.repository }}" pr view "$NUMBER" --json mergeable --jq .mergeable)
+        LABELS=$(gh --repo "${{ github.repository }}" pr view "$NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+        echo "mergeable_fresh=$MERGEABLE" >> $GITHUB_OUTPUT
+        if echo "$LABELS" | grep -q '\bai-review\b'; then echo "has_ai_review=true" >> $GITHUB_OUTPUT; else echo "has_ai_review=false" >> $GITHUB_OUTPUT; fi
+        if echo "$LABELS" | grep -q '\bdo-not-merge\b'; then echo "has_dnm=true" >> $GITHUB_OUTPUT; else echo "has_dnm=false" >> $GITHUB_OUTPUT; fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Check code quality
       id: code-quality
       run: |
@@ -173,9 +185,11 @@ jobs:
         RFC_STATUS="${{ steps.rfc-analysis.outputs.rfc_status }}"
         COMPLETION_PCT="${{ steps.rfc-analysis.outputs.completion_percentage }}"
         QUALITY_SCORE="${{ steps.code-quality.outputs.quality_score }}"
+        HAS_AI_REVIEW='${{ steps.pr-state.outputs.has_ai_review }}'
+        HAS_DNM='${{ steps.pr-state.outputs.has_dnm }}'
         
-        # Check if PR has merge conflicts
-        PR_MERGEABLE="${{ github.event.pull_request.mergeable }}"
+        # Check if PR has merge conflicts (fresh read)
+        PR_MERGEABLE='${{ steps.pr-state.outputs.mergeable_fresh }}'
         echo "PR mergeable status: $PR_MERGEABLE"
         
         # Merge criteria
@@ -206,6 +220,16 @@ jobs:
         if [ "$QUALITY_SCORE" -lt 70 ]; then
           CAN_MERGE=false
           REASONS+=("Code quality score too low: $QUALITY_SCORE/100")
+        fi
+        
+        # Require Gemini AI review label and no do-not-merge
+        if [ "$HAS_AI_REVIEW" != "true" ]; then
+          CAN_MERGE=false
+          REASONS+=("Missing required 'ai-review' label (Gemini review)")
+        fi
+        if [ "$HAS_DNM" = "true" ]; then
+          CAN_MERGE=false
+          REASONS+=("PR has 'do-not-merge' label")
         fi
         
         if [ "$CAN_MERGE" = true ]; then

--- a/.github/workflows/conflict-resolution-agent.yml
+++ b/.github/workflows/conflict-resolution-agent.yml
@@ -1,8 +1,6 @@
-name: Simple Conflict Resolution Agent
+name: Conflict Resolution Agent
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_numbers:
@@ -32,10 +30,10 @@ jobs:
       run: |
         echo "Scanning for conflicted pull requests..."
         
-        INPUT_PRS="${{ github.event.inputs.pr_numbers || 'all' }}"
+        INPUT_PRS='${{ github.event.inputs.pr_numbers || 'all' }}'
         
         if [ "$INPUT_PRS" = "all" ]; then
-          CONFLICTED_PRS=$(gh pr list --state=open --json number,mergeable --jq '.[] | select(.mergeable == "CONFLICTING") | .number' | tr '\n' ',' | sed 's/,$//')
+          CONFLICTED_PRS=$(gh --repo "${{ github.repository }}" pr list --state=open --json number,mergeable --jq '.[] | select(.mergeable == "CONFLICTING") | .number' | tr '\n' ',' | sed 's/,$//')
         else
           CONFLICTED_PRS="$INPUT_PRS"
         fi
@@ -53,25 +51,12 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         
-    - name: Resolve Copilot assignee login
-      id: resolve
-      run: |
-        echo "Resolving Copilot assignee login..."
-        CANDIDATE=$(gh api repos/${{ github.repository }}/assignees --jq '.[] | select((.login|ascii_downcase)=="copilot" or (.login|test("copilot"; "i"))) | .login' | head -n1)
-        if [ -z "$CANDIDATE" ]; then
-          echo " Could not find a Copilot assignee for this repository. Ensure Copilot Coding Agent is enabled and has access."
-          exit 1
-        fi
-        echo "copilot_login=$CANDIDATE" >> $GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ github.token }}
-        
-    - name: Assign Copilot and post guidance
+    - name: Label and post guidance
       if: steps.find-conflicts.outputs.has_conflicts == 'true'
       run: |
         echo "Processing conflicted PRs..."
         
-        CONFLICTED_PRS="${{ steps.find-conflicts.outputs.conflicted_prs }}"
+        CONFLICTED_PRS='${{ steps.find-conflicts.outputs.conflicted_prs }}'
         IFS=',' read -ra PR_ARRAY <<< "$CONFLICTED_PRS"
         
         for pr_num in "${PR_ARRAY[@]}"; do
@@ -84,22 +69,29 @@ jobs:
           echo "Processing PR #$pr_num..."
           
           # Get PR details
-          PR_INFO=$(gh pr view "$pr_num" --json headRefName,author --jq '{branch: .headRefName, author: .author.login}')
+          PR_INFO=$(gh --repo "${{ github.repository }}" pr view "$pr_num" --json headRefName,author --jq '{branch: .headRefName, author: .author.login}')
           BRANCH_NAME=$(echo "$PR_INFO" | jq -r '.branch')
           PR_AUTHOR=$(echo "$PR_INFO" | jq -r '.author')
           
-          # Skip if not a Copilot PR
-          if [[ ! "$PR_AUTHOR" == *"copilot"* ]]; then
-            echo "Skipping - not a Copilot agent PR"
-            continue
-          fi
-          
-          # Assign Copilot agent (resolved dynamically)
-          echo "Assigning Copilot agent to PR #$pr_num as ${{ steps.resolve.outputs.copilot_login }}..."
-          gh pr edit "$pr_num" --add-assignee "${{ steps.resolve.outputs.copilot_login }}" || echo "Assignment may have failed or already exists"
+          # Add or ensure merge-conflict label
+          gh --repo "${{ github.repository }}" pr edit "$pr_num" --add-label "merge-conflict" || true
           
           # Post conflict resolution guidance
-          gh pr comment "$pr_num" --body "Conflict Resolution Agent - AUTOMATIC CONFLICT RESOLUTION NEEDED - This PR has merge conflicts that need to be resolved. Action Required: 1. Checkout branch: git checkout $BRANCH_NAME 2. Rebase against main: git rebase main 3. Resolve merge conflicts in the conflicted files 4. Push updated branch: git push --force-with-lease 5. Mark this PR ready for review (remove draft status) - Please work directly on this existing PR to resolve conflicts. Integration Note: Recent RFC001 merge added comprehensive game engine architecture. Ensure your changes integrate with the new GameEngine state management and ECS architecture."
+          gh --repo "${{ github.repository }}" pr comment "$pr_num" --body "🔧 Conflict Resolution Agent
+
+This pull request currently has merge conflicts with the base branch.
+
+Recommended steps:
+1. Checkout branch: \`git checkout $BRANCH_NAME\`
+2. Rebase against main: \`git fetch origin && git rebase origin/main\`
+3. Resolve conflicts locally in the files shown by Git
+4. Push updates: \`git push --force-with-lease\`
+
+Notes:
+- Keep commits small and focused.
+- If CI fails after rebasing, re-run locally and adjust.
+
+When conflicts are resolved, this label will be cleared automatically on the next run."
           
           echo "Posted guidance to PR #$pr_num"
           

--- a/.github/workflows/create-rfc-issues.yml
+++ b/.github/workflows/create-rfc-issues.yml
@@ -9,6 +9,10 @@ on:
         required: true
         default: true
         type: boolean
+      assignee_login:
+        description: 'Optional login to assign all created RFC issues to (e.g., an agent account)'
+        required: false
+        type: string
 
 permissions:
   issues: write
@@ -25,7 +29,7 @@ jobs:
     - name: Create RFC Implementation Phase milestone (optional)
       if: ${{ inputs.create_milestone }}
       run: |
-        gh api repos/${{ github.repository }}/milestones \
+        gh --repo "${{ github.repository }}" api repos/${{ github.repository }}/milestones \
           --method POST \
           --field title="RFC Implementation Phase" \
           --field description="Implementation of all 9 RFC specifications for the dungeon crawler game" \
@@ -33,84 +37,112 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
     
+    - name: Prepare assignee flag
+      id: assign
+      run: |
+        ASSIGNEE='${{ inputs.assignee_login }}'
+        if [ -n "$ASSIGNEE" ]; then
+          echo "flag=--assignee \"$ASSIGNEE\"" >> $GITHUB_OUTPUT
+        else
+          echo "flag=" >> $GITHUB_OUTPUT
+        fi
+
     - name: Create RFC001 - Core Game Loop
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC001: Core Game Loop & State Management" \
           --body-file .github/issue-templates/rfc001-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC002 - Terminal Application Shell
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC002: Terminal.Gui Application Shell" \
           --body-file .github/issue-templates/rfc002-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC003 - Map Generation System
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC003: Map Generation & Rendering System" \
           --body-file .github/issue-templates/rfc003-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC004 - Player Movement System
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC004: Player Entity & Movement System" \
           --body-file .github/issue-templates/rfc004-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC006 - Basic Inventory
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC006: Basic Inventory System" \
           --body-file .github/issue-templates/rfc006-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC007 - Message Log UI
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC007: Simple Message Log UI" \
           --body-file .github/issue-templates/rfc007-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC008 - Save Game System
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC008: Save Game Data System" \
           --body-file .github/issue-templates/rfc008-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC009 - Simple Enemy AI
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC009: Simple Enemy AI" \
           --body-file .github/issue-templates/rfc009-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
         
     - name: Create RFC010 - Health Status Bar
       run: |
-        gh issue create \
+        gh --repo "${{ github.repository }}" issue create \
           --title "Implement RFC010: Health and Status Bar UI" \
           --body-file .github/issue-templates/rfc010-body.md \
-          --milestone "RFC Implementation Phase" || echo "Issue may already exist"
+          --milestone "RFC Implementation Phase" \
+          --label rfc-implementation \
+          ${{ steps.assign.outputs.flag }} || echo "Issue may already exist"
       env:
         GH_TOKEN: ${{ github.token }}
     
@@ -118,10 +150,10 @@ jobs:
       run: |
         echo "## 🎉 RFC Issues Created!" > summary.md
         echo "" >> summary.md
-        echo "All 9 RFC implementation issues have been created and are ready for GitHub Copilot Coding Agent assignment." >> summary.md
+        echo "All 9 RFC implementation issues have been created and are ready for agent assignment." >> summary.md
         echo "" >> summary.md
         echo "### 🚀 Next Steps:" >> summary.md
-        echo "1. **Assign to Copilot**: Go to each issue and assign to @copilot" >> summary.md
+        echo "1. **Assign to an Agent**: Optionally assign these to a bot/app or human reviewer" >> summary.md
         echo "2. **Start with Foundation**: Begin with RFC001 and RFC002 (high priority)" >> summary.md
         echo "3. **Monitor Progress**: Watch for draft pull requests from Copilot" >> summary.md
         echo "4. **Review and Iterate**: Provide feedback on Copilot's implementation" >> summary.md
@@ -131,10 +163,10 @@ jobs:
         echo "- **⚡ Core Gameplay**: RFC003, RFC004, RFC009" >> summary.md  
         echo "- **🎨 Features**: RFC006, RFC007, RFC008, RFC010" >> summary.md
         echo "" >> summary.md
-        echo "See [GETTING-STARTED-WITH-COPILOT.md](./GETTING-STARTED-WITH-COPILOT.md) for detailed instructions." >> summary.md
+        echo "See AI-REVIEWERS.md for Gemini usage and review policies." >> summary.md
         
-        gh issue create \
-          --title "🤖 RFC Issues Created - Ready for Copilot Assignment" \
+        gh --repo "${{ github.repository }}" issue create \
+          --title "🤖 RFC Issues Created - Ready for Assignment" \
           --body-file summary.md \
           --milestone "RFC Implementation Phase" || echo "Summary issue may already exist"
       env:
@@ -143,5 +175,5 @@ jobs:
     - name: Workflow completion message
       run: |
         echo "✅ All RFC issues created successfully!"
-        echo "🎯 Go to Issues tab to assign specific RFCs to @copilot"
-        echo "📖 See GETTING-STARTED-WITH-COPILOT.md for next steps"
+        echo "🎯 Go to Issues tab to assign specific RFCs to your preferred agent"
+        echo "📖 See AI-REVIEWERS.md for next steps"

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,52 @@
+name: Sync Repository Labels
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure labels exist with desired color/description
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          REPO='${{ github.repository }}'
+
+          ensure_label() {
+            local name="$1"; local color="$2"; local desc="$3"
+            if gh --repo "$REPO" label list --json name --jq '.[].name' | grep -Fxq "$name"; then
+              echo "Updating label: $name"
+              gh --repo "$REPO" label edit "$name" --color "$color" --description "$desc" || true
+            else
+              echo "Creating label: $name"
+              gh --repo "$REPO" label create "$name" --color "$color" --description "$desc" || true
+            fi
+          }
+
+          ensure_label "ai-review-requested" "8a2be2" "Gemini review has been requested and is pending"
+          ensure_label "ai-review" "0e8a16" "Gemini review completed; OK to proceed if other checks pass"
+          ensure_label "do-not-merge" "b60205" "Block merges until this label is removed"
+          ensure_label "merge-conflict" "d73a4a" "PR currently has merge conflicts with the base branch"
+          ensure_label "rfc-implementation" "1d76db" "Issue tracks implementation work for an RFC"
+          ensure_label "in-progress" "fbca04" "Work is actively in progress"
+          ensure_label "agent-assigned" "0366d6" "Assigned to an automation agent/bot"
+
+      - name: Summary
+        run: |
+          echo "✅ Labels synced. Standard labels now available:"
+          echo "- ai-review-requested"
+          echo "- ai-review"
+          echo "- do-not-merge"
+          echo "- merge-conflict"
+          echo "- rfc-implementation"
+          echo "- in-progress"
+          echo "- agent-assigned"


### PR DESCRIPTION
﻿This PR:
- Adds ai-review enforcement:
  - .github/workflows/ai-review-required.yml (status check)
  - Gates auto-merge in auto-merge-coordinator.yml on ai-review and no do-not-merge
- Generalizes/hardens agent workflows:
  - conflict-resolution-agent.yml (gh --repo, merge-conflict label, neutral guidance)
  - create-rfc-issues.yml (gh --repo, rfc-implementation label, optional assignee)
  - assign-rfc-issues-to-agent.yml (new; assignee/labels/comment)
- Deprecates Copilot-specific assignment:
  - assign-rfc-issues-to-copilot.yml now prints guidance and exits
- Adds labels-sync.yml (for standardized labels)

After merge:
- Add branch protection required status: "Require Gemini AI Review / Check for 'ai-review' label"
- Use the new assignment workflow for RFC issues.