### PR TITLE
ci(reconcile): add periodic reconcile workflow; use local reusable assignment

### DIFF
--- a/.github/workflows/reconcile-rfc-issues.yml
+++ b/.github/workflows/reconcile-rfc-issues.yml
@@ -102,7 +102,7 @@ jobs:
   assign-reconciled-rfc-issues:
     name: Auto-assign reconciled RFC issues (capacity-aware)
     needs: reconcile
-    uses: GiantCroissant-Lunar/dungeon-coding-agent/.github/workflows/assign-rfc-issues-to-agent.yml@chore/auto-assign-rfc-capacity
+    uses: ./.github/workflows/assign-rfc-issues-to-agent.yml
     with:
       issue_numbers: all
       labels: in-progress,agent-assigned


### PR DESCRIPTION
Adds .github/workflows/reconcile-rfc-issues.yml scheduled every 3 hours and uses local reusable workflow reference to avoid resolution issues. Includes manual dispatch.