### PR TITLE
ci(reconcile): add pull-requests: write for assignment job

### DIFF
--- a/.github/workflows/reconcile-rfc-issues.yml
+++ b/.github/workflows/reconcile-rfc-issues.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   ping:


### PR DESCRIPTION
The assignment reusable workflow needs to comment/label issues, which requires pull-requests: write when acting via GitHub App. Adds that permission to reconcile.