### PR TITLE
ci(reconcile): use fully-qualified reusable workflow ref for assignment

### DIFF
--- a/.github/workflows/reconcile-rfc-issues.yml
+++ b/.github/workflows/reconcile-rfc-issues.yml
@@ -107,7 +107,7 @@ jobs:
   assign:
     name: Assign reconciled RFC issues (capacity-aware)
     needs: ping
-    uses: ./.github/workflows/assign-rfc-issues-to-agent.yml
+    uses: GiantCroissant-Lunar/dungeon-coding-agent/.github/workflows/assign-rfc-issues-to-agent.yml@main
     with:
       issue_numbers: all
       labels: in-progress,agent-assigned


### PR DESCRIPTION
Switch to GiantCroissant-Lunar/dungeon-coding-agent/.github/workflows/assign-rfc-issues-to-agent.yml@main to avoid reusable resolution causing empty jobs on main. Also widened permissions previously. Expect reconcile to run end-to-end and assign RFC implementation issues.