### PR TITLE
ci(assign): ensure workflow_dispatch for manual agent assignment

### DIFF
--- a/.github/workflows/assign-rfc-issues-to-agent.yml
+++ b/.github/workflows/assign-rfc-issues-to-agent.yml
@@ -1,5 +1,7 @@
 name: Assign RFC Issues to Agent
 
+# Ensures manual dispatch is available for immediate assignment runs.
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Expose workflow_dispatch on assign-rfc-issues-to-agent so we can run assignment immediately while reconcile stabilizes.