### PR TITLE
Public readiness: label sync, capacity env, legacy workflow restriction, jq check, policies, setup guide

### DIFF
--- a/.github/workflows/assign-rfc-issues-to-agent.yml
+++ b/.github/workflows/assign-rfc-issues-to-agent.yml
@@ -46,6 +46,9 @@ permissions:
   issues: write
   contents: read
 
+env:
+  COPILOT_MAX_CAPACITY: 3
+
 jobs:
   assign:
     runs-on: ubuntu-latest
@@ -68,7 +71,8 @@ jobs:
           set -euo pipefail
           # Determine global capacity: max 3 active (rfc-implementation + agent-assigned + in-progress)
           ACTIVE=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --label agent-assigned --label in-progress --json number --jq 'length')
-          REMAINING=$((3 - ACTIVE))
+          MAX=${COPILOT_MAX_CAPACITY:-3}
+          REMAINING=$((MAX - ACTIVE))
           if [ "$REMAINING" -le 0 ]; then
             echo "capacity=0" >> $GITHUB_OUTPUT
             echo "ids=" >> $GITHUB_OUTPUT
@@ -87,6 +91,7 @@ jobs:
           echo "capacity=$REMAINING" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COPILOT_MAX_CAPACITY: 3
 
       - name: Assign/label/comment issues
         run: |

--- a/.github/workflows/auto-spawn-copilot-agents.yml
+++ b/.github/workflows/auto-spawn-copilot-agents.yml
@@ -1,0 +1,266 @@
+name: Auto-Spawn Copilot RFC Agents
+
+on:
+  # Trigger when RFC issues are ready for implementation
+  issues:
+    types: [labeled, assigned, edited]
+  
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: 'Comma-separated issue numbers to spawn agents for'
+        required: false
+        type: string
+        default: 'all'
+      force_spawn:
+        description: 'Force spawn even if already working'
+        required: false
+        type: boolean
+        default: false
+
+  # Schedule periodic check for ready RFCs
+  schedule:
+    - cron: '*/30 * * * *'  # Every 30 minutes
+
+env:
+  COPILOT_MAX_CAPACITY: 3
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan-and-spawn:
+    name: Scan for Ready RFCs and Spawn Copilot Agents
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Find RFC issues ready for agent spawn
+        id: find-issues
+        run: |
+          set -euo pipefail
+          
+          # Check global capacity (max 3 active Copilot agents)
+          ACTIVE_COUNT=$(gh --repo "${{ github.repository }}" issue list \
+            --state open \
+            --label "copilot-working" \
+            --json number --jq 'length')
+          
+          MAX_CAPACITY=${COPILOT_MAX_CAPACITY:-3}
+          AVAILABLE_SLOTS=$((MAX_CAPACITY - ACTIVE_COUNT))
+          
+          echo "Active Copilot agents: $ACTIVE_COUNT/$MAX_CAPACITY"
+          echo "active_count=$ACTIVE_COUNT" >> $GITHUB_OUTPUT
+          echo "available_slots=$AVAILABLE_SLOTS" >> $GITHUB_OUTPUT
+          
+          if [ "$AVAILABLE_SLOTS" -le 0 ]; then
+            echo "🚫 No available capacity for new Copilot agents"
+            echo "ready_issues=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Determine which issues to process
+          INPUT_ISSUES="${{ github.event.inputs.issue_numbers }}"
+          
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "$INPUT_ISSUES" ]; then
+            if [ "$INPUT_ISSUES" == "all" ]; then
+              CANDIDATE_ISSUES=$(gh --repo "${{ github.repository }}" issue list \
+                --state open \
+                --label "rfc-implementation" \
+                --label "agent-assigned" \
+                --json number --jq '.[].number' | tr '\n' ',' | sed 's/,$//')
+            else
+              CANDIDATE_ISSUES="$INPUT_ISSUES"
+            fi
+          else
+            # Auto-discovery: find RFC issues ready for implementation
+            CANDIDATE_ISSUES=$(gh --repo "${{ github.repository }}" issue list \
+              --state open \
+              --label "rfc-implementation" \
+              --label "agent-assigned" \
+              --json number,labels --jq '
+                map(select(
+                  (.labels | map(.name) | contains(["rfc-implementation", "agent-assigned"])) and
+                  (.labels | map(.name) | contains(["copilot-working"]) | not)
+                )) | .[].number
+              ' | tr '\n' ',' | sed 's/,$//')
+          fi
+          
+          echo "Candidate issues: $CANDIDATE_ISSUES"
+          echo "ready_issues=$CANDIDATE_ISSUES" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Spawn Copilot agents for ready RFCs
+        if: steps.find-issues.outputs.ready_issues != ''
+        run: |
+          set -euo pipefail
+          
+          IFS=',' read -ra ISSUE_ARRAY <<< "${{ steps.find-issues.outputs.ready_issues }}"
+          AVAILABLE_SLOTS=${{ steps.find-issues.outputs.available_slots }}
+          FORCE_SPAWN="${{ github.event.inputs.force_spawn }}"
+          
+          SPAWNED_COUNT=0
+          
+          for issue_num in "${ISSUE_ARRAY[@]}"; do
+            issue_num=$(echo "$issue_num" | xargs)  # trim whitespace
+            [ -z "$issue_num" ] && continue
+            
+            if [ "$SPAWNED_COUNT" -ge "$AVAILABLE_SLOTS" ]; then
+              echo "🛑 Capacity limit reached. Stopping agent spawn."
+              break
+            fi
+            
+            echo "🎯 Processing issue #$issue_num"
+            
+            # Get issue details
+            ISSUE_DATA=$(gh --repo "${{ github.repository }}" issue view "$issue_num" --json title,labels,assignees)
+            ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+            
+            # Extract RFC number
+            RFC_NUM=$(echo "$ISSUE_TITLE" | grep -o 'RFC[0-9]\{3\}' | head -1 || echo "")
+            if [ -z "$RFC_NUM" ]; then
+              echo "⚠️ Could not extract RFC number from: $ISSUE_TITLE"
+              continue
+            fi
+            
+            # Check if already working (unless forced)
+            HAS_WORKING_LABEL=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "copilot-working" && echo "true" || echo "false")
+            if [ "$HAS_WORKING_LABEL" == "true" ] && [ "$FORCE_SPAWN" != "true" ]; then
+              echo "⏭️ Skipping #$issue_num - already has copilot-working label"
+              continue
+            fi
+            
+            # Find RFC file
+            RFC_FILE=$(find docs/RFC/ -name "$RFC_NUM-*.md" | head -1 || echo "")
+            if [ -z "$RFC_FILE" ]; then
+              echo "⚠️ RFC file not found for $RFC_NUM"
+              continue
+            fi
+            
+            echo "🚀 Spawning Copilot agent for #$issue_num ($RFC_NUM)"
+            
+            # Add copilot-working label
+            gh --repo "${{ github.repository }}" issue edit "$issue_num" --add-label "copilot-working"
+            
+            # Create enhanced spawn comment with RFC context
+            RFC_SUMMARY=$(head -20 "$RFC_FILE" | grep -E "^## 🎯|^## 📖" -A 3 || echo "See RFC for full details")
+            
+            cat > /tmp/copilot_spawn_comment.md << EOF
+# 🤖 GitHub Copilot Agent Spawn - $RFC_NUM Implementation
+
+@copilot You are now assigned to implement $RFC_NUM. Please follow these comprehensive instructions:
+
+## 📋 RFC Overview
+$RFC_SUMMARY
+
+**Full RFC Specification**: \`$RFC_FILE\`
+
+## 🎯 Implementation Mission
+1. **Study the complete RFC** - Read \`$RFC_FILE\` thoroughly
+2. **Create feature branch** - Use naming: \`feature/$(echo $RFC_NUM | tr '[:upper:]' '[:lower:]')-implementation\`
+3. **Follow architecture patterns** - Arch ECS + Terminal.Gui v2 as specified in AGENTS.md
+4. **Implement ALL acceptance criteria** - Complete every checkbox in the RFC
+5. **Write comprehensive tests** - Achieve >80% coverage
+6. **Create pull request** - With detailed implementation description
+
+## 🏗️ Technical Architecture (Critical)
+
+### ECS Pattern Requirements:
+- **Components**: Pure data structs only (no methods)
+- **Systems**: Logic classes inheriting \`SystemBase<World, float>\`
+- **Event Communication**: Use \`GameEvents.RaiseXXX()\` for inter-system messaging
+
+### File Organization:
+\`\`\`
+src/DungeonCodingAgent.Game/
+├── Components/     # Data structures ($RFC_NUM components)
+├── Systems/        # Game logic ($RFC_NUM systems) 
+├── UI/            # Terminal.Gui views ($RFC_NUM UI)
+├── Core/          # Events, utilities ($RFC_NUM events)
+└── Generation/    # Content generation (if applicable)
+\`\`\`
+
+### Code Example Pattern:
+\`\`\`csharp
+// Component (data only)
+public struct Position 
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+}
+
+// System (logic only)
+public class MovementSystem : SystemBase<World, float>
+{
+    public override void Update(World world, float deltaTime)
+    {
+        // Implementation following RFC specifications
+    }
+}
+\`\`\`
+
+## ✅ Definition of Done
+- [ ] All RFC acceptance criteria checkboxes completed
+- [ ] Unit tests written and passing (>80% coverage)
+- [ ] Integration tests verify compatibility with existing systems
+- [ ] Code follows established architectural patterns  
+- [ ] Terminal.Gui integration working (if UI components)
+- [ ] Event system integration complete (if applicable)
+- [ ] Pull request created with comprehensive description
+- [ ] No build warnings or errors
+
+## 📚 Essential Resources
+- **Architecture Guidelines**: \`AGENTS.md\` and \`.github/copilot-instructions.md\`
+- **RFC Specification**: \`$RFC_FILE\` (complete implementation spec)
+- **Existing Patterns**: Study current codebase for established conventions
+- **Dependencies**: Terminal.Gui 2.0.0, Arch 2.0.0, xUnit testing
+
+## 🎮 Expected Deliverable
+A complete, tested implementation of $RFC_NUM that:
+- Follows the project's ECS architecture
+- Integrates seamlessly with existing systems
+- Provides the functionality described in the RFC
+- Includes comprehensive test coverage
+- Is ready for production use in the dungeon crawler game
+
+**Start by creating your feature branch and reading the complete RFC specification. Comment your progress and ask questions as needed.**
+
+---
+*Auto-spawned by GitHub Actions - dungeon-coding-agent RFC automation system*
+EOF
+            
+            # Post the spawn comment
+            gh --repo "${{ github.repository }}" issue comment "$issue_num" --body-file /tmp/copilot_spawn_comment.md
+            
+            echo "✅ Spawned Copilot agent for issue #$issue_num ($RFC_NUM)"
+            SPAWNED_COUNT=$((SPAWNED_COUNT + 1))
+            
+            # Brief delay to avoid rate limiting
+            sleep 2
+          done
+          
+          echo "🎉 Successfully spawned $SPAWNED_COUNT Copilot agent(s)"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COPILOT_MAX_CAPACITY: 3
+
+      - name: Update spawn status
+        run: |
+          echo "## 🤖 Copilot Agent Spawn Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Active Capacity**: ${{ steps.find-issues.outputs.active_count || 0 }}/${{ env.COPILOT_MAX_CAPACITY }} agents working" >> $GITHUB_STEP_SUMMARY  
+          echo "- **Available Slots**: ${{ steps.find-issues.outputs.available_slots || 0 }} slots free" >> $GITHUB_STEP_SUMMARY
+          echo "- **Ready Issues**: ${{ steps.find-issues.outputs.ready_issues || 'none' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/call-trigger-scripts.yml
+++ b/.github/workflows/call-trigger-scripts.yml
@@ -1,0 +1,120 @@
+name: Call Trigger Scripts for Copilot Spawning
+
+on:
+  workflow_dispatch:
+    inputs:
+      script_type:
+        description: 'Which trigger script to use'
+        required: true
+        type: choice
+        options:
+          - 'bash'
+          - 'powershell'
+        default: 'bash'
+      issue_number:
+        description: 'Issue number to trigger Copilot for'
+        required: true
+        type: number
+      force_trigger:
+        description: 'Force trigger even if already working'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  call-bash-script:
+    name: Call Bash Trigger Script
+    runs-on: ubuntu-latest
+    if: github.event.inputs.script_type == 'bash'
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Make script executable
+        run: chmod +x ./trigger-copilot-rfc.sh
+
+      - name: Run bash trigger script
+        run: |
+          FORCE_FLAG=""
+          if [ "${{ github.event.inputs.force_trigger }}" == "true" ]; then
+            FORCE_FLAG="--force"
+          fi
+          
+          ./trigger-copilot-rfc.sh \
+            --issue ${{ github.event.inputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            $FORCE_FLAG
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  call-powershell-script:
+    name: Call PowerShell Trigger Script  
+    runs-on: windows-latest
+    if: github.event.inputs.script_type == 'powershell'
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run PowerShell trigger script
+        shell: powershell
+        run: |
+          $ForceFlag = if ("${{ github.event.inputs.force_trigger }}" -eq "true") { $true } else { $false }
+          
+          .\trigger-copilot-rfc.ps1 `
+            -IssueNumber ${{ github.event.inputs.issue_number }} `
+            -Repository "${{ github.repository }}" `
+            -Force:$ForceFlag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  summary:
+    name: Execution Summary
+    runs-on: ubuntu-latest
+    needs: [call-bash-script, call-powershell-script]
+    if: always()
+    
+    steps:
+      - name: Create summary
+        run: |
+          echo "## 📜 Script Execution Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- **Script Type**: ${{ github.event.inputs.script_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Issue Number**: #${{ github.event.inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY  
+          echo "- **Force Trigger**: ${{ github.event.inputs.force_trigger }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Repository**: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.call-bash-script.result }}" == "success" ]; then
+            echo "- **Bash Script**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.call-bash-script.result }}" == "failure" ]; then
+            echo "- **Bash Script**: ❌ Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.call-bash-script.result }}" == "skipped" ]; then
+            echo "- **Bash Script**: ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.call-powershell-script.result }}" == "success" ]; then
+            echo "- **PowerShell Script**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.call-powershell-script.result }}" == "failure" ]; then
+            echo "- **PowerShell Script**: ❌ Failed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.call-powershell-script.result }}" == "skipped" ]; then
+            echo "- **PowerShell Script**: ⏭️ Skipped" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -47,6 +47,8 @@ jobs:
           ensure_label "rfc-implementation" "1d76db" "Issue tracks implementation work for an RFC"
           ensure_label "in-progress" "fbca04" "Work is actively in progress"
           ensure_label "agent-assigned" "0366d6" "Assigned to an automation agent/bot"
+          ensure_label "copilot-working" "5319e7" "GitHub Copilot coding agent is actively working on this issue"
+          ensure_label "agent-work" "1D76DB" "Work authored by an AI agent"
 
       - name: Summary
         run: |
@@ -58,3 +60,5 @@ jobs:
           echo "- rfc-implementation"
           echo "- in-progress"
           echo "- agent-assigned"
+          echo "- copilot-working"
+          echo "- agent-work"

--- a/.github/workflows/one-shot-assign.yml
+++ b/.github/workflows/one-shot-assign.yml
@@ -11,9 +11,58 @@ permissions:
 jobs:
   assign:
     name: Assign RFC issues now (capacity-aware)
-    uses: GiantCroissant-Lunar/dungeon-coding-agent/.github/workflows/assign-rfc-issues-to-agent.yml@main
-    with:
-      issue_numbers: all
-      labels: in-progress,agent-assigned
-      add_comment: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Capacity-aware assign and label
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Compute remaining capacity (max 3 active)
+          ACTIVE=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --label agent-assigned --label in-progress --json number --jq 'length')
+          ACTIVE=${ACTIVE:-0}
+          REMAINING=$((3 - ACTIVE))
+          echo "Active assigned RFCs: $ACTIVE. Remaining capacity: $REMAINING"
+          if [ "$REMAINING" -le 0 ]; then
+            echo "Capacity is full (3). Skipping."
+            exit 0
+          fi
+          # Candidates: open RFC implementation issues
+          IDS=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --json number --jq '.[].number' | tr '\n' ' ')
+          ASSIGNED=0
+          for id in $IDS; do
+            [ "$ASSIGNED" -ge "$REMAINING" ] && break
+            # Skip if already claimed or assigned
+            CLAIMED=$(gh --repo "${{ github.repository }}" issue view "$id" --json labels --jq '[.labels[].name] | index("agent-assigned") // null')
+            [ "$CLAIMED" != "null" ] && continue
+            ASSIGNEES_COUNT=$(gh --repo "${{ github.repository }}" issue view "$id" --json assignees --jq '.assignees | length')
+            [ "$ASSIGNEES_COUNT" -gt 0 ] && continue
+            # Apply labels
+            gh --repo "${{ github.repository }}" issue edit "$id" --add-label agent-assigned --add-label in-progress || true
+            # Comment guidance
+            TMP_FILE=$(mktemp)
+            cat > "$TMP_FILE" << 'EOF'
+Guidance for implementing this RFC:
+
+- Follow the RFC acceptance criteria and update checkboxes as you progress.
+- Create a feature branch per repo conventions.
+- Write and run tests locally; aim for meaningful coverage.
+- Open a draft PR early; request Gemini review by commenting `/gemini review`.
+- Keep commits small and descriptive.
+
+Refer to AI-REVIEWERS.md for Gemini Code Assist usage and labels.
+EOF
+            gh --repo "${{ github.repository }}" issue comment "$id" --body-file "$TMP_FILE" || true
+            rm -f "$TMP_FILE"
+            ASSIGNED=$((ASSIGNED + 1))
+            echo "Assigned issue #$id ($ASSIGNED/$REMAINING)"
+          done
+          echo "Done. Assigned: $ASSIGNED"

--- a/.github/workflows/reconcile-rfc-issues.yml
+++ b/.github/workflows/reconcile-rfc-issues.yml
@@ -108,9 +108,58 @@ jobs:
   assign:
     name: Assign reconciled RFC issues (capacity-aware)
     needs: ping
-    uses: GiantCroissant-Lunar/dungeon-coding-agent/.github/workflows/assign-rfc-issues-to-agent.yml@main
-    with:
-      issue_numbers: all
-      labels: in-progress,agent-assigned
-      add_comment: true
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Capacity-aware assign and label
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Compute remaining capacity (max 3 active)
+          ACTIVE=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --label agent-assigned --label in-progress --json number --jq 'length')
+          ACTIVE=${ACTIVE:-0}
+          REMAINING=$((3 - ACTIVE))
+          echo "Active assigned RFCs: $ACTIVE. Remaining capacity: $REMAINING"
+          if [ "$REMAINING" -le 0 ]; then
+            echo "Capacity is full (3). Skipping."
+            exit 0
+          fi
+          # Candidates: open RFC implementation issues
+          IDS=$(gh --repo "${{ github.repository }}" issue list --state open --label rfc-implementation --json number --jq '.[].number' | tr '\n' ' ')
+          ASSIGNED=0
+          for id in $IDS; do
+            [ "$ASSIGNED" -ge "$REMAINING" ] && break
+            # Skip if already claimed or assigned
+            CLAIMED=$(gh --repo "${{ github.repository }}" issue view "$id" --json labels --jq '[.labels[].name] | index("agent-assigned") // null')
+            [ "$CLAIMED" != "null" ] && continue
+            ASSIGNEES_COUNT=$(gh --repo "${{ github.repository }}" issue view "$id" --json assignees --jq '.assignees | length')
+            [ "$ASSIGNEES_COUNT" -gt 0 ] && continue
+            # Apply labels
+            gh --repo "${{ github.repository }}" issue edit "$id" --add-label agent-assigned --add-label in-progress || true
+            # Comment guidance
+            TMP_FILE=$(mktemp)
+            cat > "$TMP_FILE" << 'EOF'
+Guidance for implementing this RFC:
+
+- Follow the RFC acceptance criteria and update checkboxes as you progress.
+- Create a feature branch per repo conventions.
+- Write and run tests locally; aim for meaningful coverage.
+- Open a draft PR early; request Gemini review by commenting `/gemini review`.
+- Keep commits small and descriptive.
+
+Refer to AI-REVIEWERS.md for Gemini Code Assist usage and labels.
+EOF
+            gh --repo "${{ github.repository }}" issue comment "$id" --body-file "$TMP_FILE" || true
+            rm -f "$TMP_FILE"
+            ASSIGNED=$((ASSIGNED + 1))
+            echo "Assigned issue #$id ($ASSIGNED/$REMAINING)"
+          done
+          echo "Done. Assigned: $ASSIGNED"

--- a/.github/workflows/reconcile-rfc-issues.yml
+++ b/.github/workflows/reconcile-rfc-issues.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write

--- a/.github/workflows/trigger-copilot-implementation.yml
+++ b/.github/workflows/trigger-copilot-implementation.yml
@@ -1,0 +1,148 @@
+name: Trigger Copilot RFC Implementation
+
+# NOTE: Legacy workflow. Prefer using `Auto-Spawn Copilot RFC Agents`.
+# This workflow is restricted to manual dispatch to avoid confusion with the
+# primary auto-spawn system.
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to trigger Copilot implementation'
+        required: true
+        type: number
+      force_trigger:
+        description: 'Force trigger even if already in progress'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  trigger-copilot:
+    name: Trigger GitHub Copilot Coding Agent
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issues' && 
+       contains(github.event.issue.labels.*.name, 'rfc-implementation') && 
+       contains(github.event.issue.labels.*.name, 'agent-assigned') &&
+       !contains(github.event.issue.labels.*.name, 'copilot-working')) ||
+      (github.event_name == 'workflow_dispatch')
+    
+    steps:
+      - name: Get GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Determine issue number
+        id: issue
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.issue_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if Copilot should be triggered
+        id: check
+        run: |
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          
+          # Get issue details
+          ISSUE_DATA=$(gh --repo "${{ github.repository }}" issue view "$ISSUE_NUM" --json labels,title,body,assignees)
+          
+          # Check required labels
+          HAS_RFC=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "rfc-implementation" && echo "true" || echo "false")
+          HAS_AGENT=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "agent-assigned" && echo "true" || echo "false")
+          HAS_WORKING=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "copilot-working" && echo "true" || echo "false")
+          
+          # Extract RFC number from title
+          RFC_NUM=$(echo "$ISSUE_DATA" | jq -r '.title' | grep -o 'RFC[0-9]\+' | head -1 || echo "")
+          
+          if [ "$HAS_RFC" != "true" ] || [ "$HAS_AGENT" != "true" ]; then
+            echo "should_trigger=false" >> $GITHUB_OUTPUT
+            echo "reason=Missing required labels (rfc-implementation and agent-assigned)" >> $GITHUB_OUTPUT
+          elif [ "$HAS_WORKING" == "true" ] && [ "${{ github.event.inputs.force_trigger }}" != "true" ]; then
+            echo "should_trigger=false" >> $GITHUB_OUTPUT  
+            echo "reason=Copilot already working (copilot-working label present)" >> $GITHUB_OUTPUT
+          elif [ -z "$RFC_NUM" ]; then
+            echo "should_trigger=false" >> $GITHUB_OUTPUT
+            echo "reason=Could not extract RFC number from issue title" >> $GITHUB_OUTPUT
+          else
+            echo "should_trigger=true" >> $GITHUB_OUTPUT
+            echo "rfc_number=$RFC_NUM" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Trigger GitHub Copilot Coding Agent
+        if: steps.check.outputs.should_trigger == 'true'
+        run: |
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          RFC_NUM="${{ steps.check.outputs.rfc_number }}"
+          
+          # Mark as Copilot working
+          gh --repo "${{ github.repository }}" issue edit "$ISSUE_NUM" --add-label "copilot-working"
+          
+          # Create comprehensive implementation comment to trigger Copilot
+          RFC_FILE="docs/RFC/${RFC_NUM}-*.md"
+          RFC_ACTUAL_FILE=$(find docs/RFC/ -name "${RFC_NUM}-*.md" | head -1 || echo "")
+          
+          COPILOT_COMMENT=$(cat << 'EOF'
+@copilot Please implement this RFC following the project's coding standards and architecture.
+
+## 🎯 Implementation Instructions
+
+1. **Read the RFC**: Study the complete RFC specification linked in this issue
+2. **Follow Architecture**: Use Arch ECS patterns - Components are data, Systems are logic  
+3. **Use Terminal.Gui**: All UI must use Terminal.Gui v2 framework
+4. **Write Tests**: Achieve >80% test coverage with unit and integration tests
+5. **Check Acceptance Criteria**: Complete ALL checkboxes in the RFC
+6. **Create Feature Branch**: Use `feature/rfc###-[description]` naming convention
+
+## 📋 Technical Requirements
+
+- **ECS Patterns**: Components as structs, Systems inherit from `SystemBase<World, float>`
+- **Event System**: Use `GameEvents.RaiseXXX()` for inter-system communication
+- **File Organization**: Follow `src/DungeonCodingAgent.Game/[Components|Systems|UI|Core]/` structure
+- **Testing**: Write comprehensive tests in `tests/DungeonCodingAgent.Tests/`
+- **Code Style**: Follow existing C# conventions in the codebase
+
+## 🔗 Key Resources
+
+- **Architecture Guidelines**: See `AGENTS.md` and `.github/copilot-instructions.md`
+- **RFC Document**: Check the `docs/RFC/` folder for complete specification
+- **Existing Code**: Study current patterns in the codebase
+- **Dependencies**: Terminal.Gui 2.0.0, Arch 2.0.0, xUnit for tests
+
+## ✅ Definition of Done
+
+- [ ] All RFC acceptance criteria checkboxes completed
+- [ ] Unit tests written and passing (>80% coverage)
+- [ ] Integration tests verify system works with existing code
+- [ ] Code follows project architectural patterns
+- [ ] Feature works as demonstrated in RFC
+- [ ] Pull request created with detailed description
+
+Please create a feature branch and implement this RFC completely. Comment with your progress and questions as needed.
+EOF
+)
+
+          # Post the comprehensive implementation comment
+          echo "$COPILOT_COMMENT" | gh --repo "${{ github.repository }}" issue comment "$ISSUE_NUM" --body-file -
+          
+          echo "✅ Triggered GitHub Copilot for issue #$ISSUE_NUM ($RFC_NUM)"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Log skip reason
+        if: steps.check.outputs.should_trigger == 'false'
+        run: |
+          echo "⚠️ Skipping Copilot trigger for issue #${{ steps.issue.outputs.number }}"
+          echo "Reason: ${{ steps.check.outputs.reason }}"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant Code of Conduct.
+
+- Project maintainers, contributors, and AI agents must foster an open and welcoming environment.
+- Be respectful and constructive. Harassment or discrimination is not tolerated.
+
+## Our Standards
+
+- Use welcoming and inclusive language
+- Be respectful of differing viewpoints and experiences
+- Gracefully accept constructive criticism
+- Focus on what is best for the community
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at: opensource@your-org.example.
+
+All complaints will be reviewed, investigated, and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for your interest in contributing! This project is designed for RFC-driven, parallel AI + human development.
+
+## How Work Is Organized
+
+- RFC specs live in `docs/RFC/`.
+- Each implementation task is tracked as an issue titled `RFC###: [Title] - Implementation` with label `rfc-implementation`.
+- Automation assigns/labels issues and posts detailed guidance for GitHub Copilot Coding Agents.
+
+## Getting Started
+
+1. Read the project overview in `README.md` and `AGENTS.md`.
+2. Browse RFCs in `docs/RFC/README.md`.
+3. Pick an RFC that is `📝 Draft` and has dependencies satisfied.
+4. Create a feature branch: `feature/rfc###-short-description`.
+5. Implement per RFC acceptance criteria with tests (>80% preferred for new code).
+
+## Development
+
+- Runtime: .NET 8
+- UI: Terminal.Gui v2
+- ECS: Arch
+- Tests: xUnit
+
+Follow the architecture and patterns described in `AGENTS.md` and `.github/copilot-instructions.md`.
+
+## Submitting Changes
+
+1. Ensure all tests pass locally (`dotnet test`).
+2. Open a Pull Request with:
+   - Clear description referencing the RFC and acceptance criteria
+   - Notes on tests and coverage
+   - Any migration or compatibility concerns
+3. Request review; do not merge directly to `main`.
+
+## Code of Conduct
+
+This project adheres to the [Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to abide by its terms.
+
+## Security Issues
+
+Please do not open public issues for security vulnerabilities. See [SECURITY.md](./SECURITY.md) for responsible disclosure.

--- a/COPILOT-RFC-AUTOMATION.md
+++ b/COPILOT-RFC-AUTOMATION.md
@@ -1,0 +1,256 @@
+## ⚠️ Limitations
+
+- GitHub does not provide an API or Actions capability to programmatically start a Copilot Coding Agent session. Workflows and scripts here prepare issues (labels and comments) with all context required, but the agent session is started by a user via the issue UI (“Let Copilot work on this”) or via Copilot Chat, subject to org/repo policy.
+- Comments mentioning `@copilot` do not auto-start the agent; they provide instructions/context only.
+- Ensure Copilot Coding Agent is enabled in your organization/repository settings; otherwise the UI button will not appear.
+# 🤖 GitHub Copilot RFC Auto-Implementation System
+
+This document describes the automated system for triggering GitHub Copilot coding agents to implement RFCs in the dungeon-coding-agent project.
+
+## 🎯 Overview
+
+The system bridges the gap between RFC creation and actual implementation by automatically triggering GitHub Copilot coding agents when RFC issues are ready for implementation.
+
+## 🏗️ Architecture
+
+### **Workflow Chain**
+1. **RFC Created** → `docs/RFC/RFC###-*.md` file added
+2. **Issue Auto-Created** → `auto-create-rfc-issues-on-push.yml` creates implementation issue
+3. **Agent Assignment** → `assign-rfc-issues-to-agent.yml` assigns and labels issue
+4. **Copilot Auto-Spawned** → Multiple automated options trigger GitHub Copilot
+5. **Implementation** → GitHub Copilot coding agent implements RFC
+6. **Pull Request** → Copilot creates PR with implementation
+
+### **Key Components**
+
+#### **Primary Auto-Spawn System** (`.github/workflows/auto-spawn-copilot-agents.yml`)
+- **Automatic Discovery**: Scans for ready RFC issues every 30 minutes
+- **Event-Driven**: Triggers on issue labels, assignments, edits
+- **Capacity Management**: Maintains max 3 concurrent Copilot agents
+- **Enhanced Instructions**: Posts comprehensive RFC-specific implementation guides
+- **Manual Override**: Workflow dispatch for immediate spawning
+
+#### **Legacy Trigger System** (`.github/workflows/trigger-copilot-implementation.yml`)  
+- Simpler event-based triggering
+- Posts basic implementation instructions
+- Still functional for fallback scenarios
+
+#### **Script Integration System** (`.github/workflows/call-trigger-scripts.yml`)
+- Calls standalone PowerShell/Bash scripts from GitHub Actions
+- Useful for testing and manual control
+- Provides cross-platform script execution in CI/CD
+
+#### **Manual Trigger Scripts**
+- **PowerShell**: `trigger-copilot-rfc.ps1` - Windows environments
+- **Bash**: `trigger-copilot-rfc.sh` - Unix/Linux/WSL environments
+
+#### **Configuration Files**
+- **`.github/copilot-instructions.md`** - Comprehensive Copilot instructions
+- **`AGENTS.md`** - Detailed coding standards and architecture patterns
+
+## 🚀 Usage
+
+### **Fully Automatic Preparation** ⭐ **Recommended**
+The primary system (`auto-spawn-copilot-agents.yml`) automatically prepares issues for Copilot by:
+1. **Scans every 30 minutes** for RFC issues with `rfc-implementation` + `agent-assigned` labels
+2. **Triggers on events** when issues are labeled, assigned, or edited
+3. **Spawns Copilot agents** with comprehensive, RFC-specific instructions
+4. **Manages capacity** to prevent overload (max 3 concurrent agents)
+5. Posting detailed guidance comments and labels to maximize success
+
+> Note: Starting a Copilot Coding Agent session itself is not programmatically supported by GitHub Actions. See Limitations below.
+
+### **Manual Control Options**
+When you need direct control:
+
+### **Manual Triggering**
+
+#### **PowerShell (Windows)**
+```powershell
+# Basic usage
+.\trigger-copilot-rfc.ps1 -IssueNumber 42
+
+# With custom repository
+.\trigger-copilot-rfc.ps1 -IssueNumber 42 -Repository "username/repo-name"
+
+# Force trigger even if already working
+.\trigger-copilot-rfc.ps1 -IssueNumber 42 -Force
+```
+
+#### **Bash (Unix/Linux/WSL)**
+```bash
+# Basic usage
+./trigger-copilot-rfc.sh --issue 42
+
+# With custom repository  
+./trigger-copilot-rfc.sh --issue 42 --repo "username/repo-name"
+
+# Force trigger even if already working
+./trigger-copilot-rfc.sh --issue 42 --force
+
+# Show help
+./trigger-copilot-rfc.sh --help
+```
+
+#### **GitHub Actions (Manual Dispatch)**
+
+**Primary Auto-Spawn System:**
+```bash
+# Spawn agents for all ready RFCs
+gh workflow run "Auto-Spawn Copilot RFC Agents" \
+  --field issue_numbers=all \
+  --field force_spawn=false
+
+# Spawn agent for specific issues
+gh workflow run "Auto-Spawn Copilot RFC Agents" \
+  --field issue_numbers="42,43,44" \
+  --field force_spawn=true
+```
+
+**Script Integration System:**
+```bash
+# Call bash script via workflow
+gh workflow run "Call Trigger Scripts for Copilot Spawning" \
+  --field script_type=bash \
+  --field issue_number=42 \
+  --field force_trigger=false
+
+# Call PowerShell script via workflow  
+gh workflow run "Call Trigger Scripts for Copilot Spawning" \
+  --field script_type=powershell \
+  --field issue_number=42 \
+  --field force_trigger=true
+```
+
+**Legacy System:**
+```bash
+# Via GitHub CLI
+gh workflow run "Trigger Copilot RFC Implementation" \
+  --field issue_number=42 \
+  --field force_trigger=false
+```
+
+**Via GitHub Web Interface:**
+Go to Actions → Select desired workflow → "Run workflow"
+
+## 📋 Configuration
+
+### **Required Secrets**
+- `APP_ID`: GitHub App ID for authentication
+- `APP_PRIVATE_KEY`: GitHub App private key
+
+### **Required Labels**
+The system automatically creates these labels:
+- `rfc-implementation`: Marks RFC implementation issues
+- `agent-work`: Indicates AI-authored work
+- `agent-assigned`: Issue assigned to AI agent
+- `ai-review-requested`: AI review requested
+- `copilot-working`: GitHub Copilot is actively working
+- `in-progress`: Work is actively being done
+
+### **Capacity Management**
+- **Default Limit**: 3 simultaneous RFC implementations
+- **Configurable**: Modify `REMAINING=$((3 - ACTIVE))` in workflow
+- **Prevents Overload**: Ensures quality by limiting concurrent work
+
+## 🎯 Copilot Instructions
+
+When triggered, the system posts comprehensive instructions to the issue including:
+
+### **Implementation Guidelines**
+- Read complete RFC specification
+- Follow Arch ECS architecture patterns
+- Use Terminal.Gui v2 for all UI
+- Achieve >80% test coverage
+- Complete all RFC acceptance criteria
+
+### **Technical Standards**
+- **Components**: Pure data structures (structs)
+- **Systems**: Logic classes inheriting from `SystemBase<World, float>`
+- **Events**: Use `GameEvents.RaiseXXX()` for inter-system communication
+- **File Organization**: Follow established project structure
+
+### **Definition of Done**
+- [ ] All RFC acceptance criteria checkboxes completed
+- [ ] Unit tests written and passing (>80% coverage)
+- [ ] Integration tests verify system works with existing code
+- [ ] Code follows project architectural patterns
+- [ ] Feature works as demonstrated in RFC
+- [ ] Pull request created with detailed description
+
+## 🔍 Monitoring & Debugging
+
+### **Check System Status**
+```bash
+# List RFC implementation issues
+gh issue list --label "rfc-implementation" --state open
+
+# List active Copilot work
+gh issue list --label "copilot-working" --state open
+
+# View specific issue
+gh issue view 42
+```
+
+### **Common Issues**
+
+#### **"Copilot not responding"**
+- Check if issue has `copilot-working` label
+- Verify issue has proper RFC number in title
+- Ensure issue has both `rfc-implementation` and `agent-assigned` labels
+
+#### **"Multiple Copilots working on same RFC"**
+- System prevents this with `copilot-working` label
+- Use `--force` flag only if certain previous work was abandoned
+
+#### **"Capacity limit reached"**
+- System limits to 3 simultaneous implementations
+- Wait for current work to complete or increase limit in workflow
+
+## 🛠️ Customization
+
+### **Modify Capacity Limit**
+Edit `trigger-copilot-implementation.yml`:
+```yaml
+REMAINING=$((5 - ACTIVE))  # Change from 3 to 5
+```
+
+### **Add Custom Instructions**
+Edit `.github/copilot-instructions.md` to add project-specific guidance.
+
+### **Change Trigger Conditions**
+Edit the workflow `if` condition to modify when Copilot is triggered.
+
+## 🔗 Integration Points
+
+### **Existing Workflows**
+- **Works with**: `auto-create-rfc-issues-on-push.yml`
+- **Works with**: `assign-rfc-issues-to-agent.yml`
+- **Extends**: GitHub's native Copilot coding agent functionality
+
+### **External Dependencies**
+- **GitHub Copilot**: Pro, Business, or Enterprise plan required
+- **GitHub CLI**: For manual trigger scripts
+- **Repository Permissions**: Issues and pull requests write access
+
+## 🎮 Example Flow
+
+1. **Developer adds RFC**: `docs/RFC/RFC001-Core-Game-Loop.md`
+2. **System creates issue**: "RFC001: Core Game Loop - Implementation"  
+3. **System assigns agent**: Adds `agent-assigned` and `in-progress` labels
+4. **Copilot triggered**: Posts comprehensive implementation comment
+5. **Copilot implements**: Creates feature branch, writes code, adds tests
+6. **Copilot creates PR**: Submits implementation for review
+7. **Review & merge**: Human review and merge to main branch
+
+## 📚 References
+
+- [GitHub Copilot Coding Agent Documentation](https://docs.github.com/en/copilot/concepts/coding-agent/coding-agent)
+- [Project Architecture Guidelines](./AGENTS.md)
+- [RFC Template and Examples](./docs/RFC/)
+
+---
+
+## 🎯 Ready to Auto-Implement RFCs!
+
+This system transforms your detailed RFCs into working code through automated GitHub Copilot coding agent triggering. Each RFC becomes a well-guided implementation task that Copilot can complete following your project's standards and architecture.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Dungeon Coding Agent Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -133,3 +133,11 @@ See [docs/RFC/README.md](docs/RFC/README.md) for the complete RFC index and assi
 
 ### **For Human Developers:**
 Pick an RFC from [docs/RFC/README.md](docs/RFC/README.md) and start implementing! Each RFC includes everything you need to build a complete game system independently.
+
+## 🏛️ Public Repository Policies & Setup
+
+- License: See [LICENSE](./LICENSE)
+- Code of Conduct: See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Contributing Guide: See [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Security Policy: See [SECURITY.md](./SECURITY.md)
+- GitHub App and Secrets Setup for automation: [docs/GITHUB-APP-SETUP.md](./docs/GITHUB-APP-SETUP.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+We support security fixes on the `main` branch. For released versions, please open an issue to discuss backports if needed.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately. Do not open a public issue.
+
+- Email: security@your-org.example
+- Include: Steps to reproduce, affected versions/commits, impact, suggested fix if available
+
+We will acknowledge receipt within 72 hours and keep you updated on remediation progress. Once a fix is available, we will coordinate a public disclosure.
+
+## Scope
+
+- Source under this repository
+- GitHub Actions workflows used by this repository
+
+Third-party dependencies should be reported to their respective maintainers.

--- a/docs/GITHUB-APP-SETUP.md
+++ b/docs/GITHUB-APP-SETUP.md
@@ -1,0 +1,64 @@
+# GitHub App Setup for RFC Automation
+
+This repo uses a GitHub App to authenticate automation workflows (creating issues, assigning labels, posting comments, etc.). Follow these steps to set it up for a public repository.
+
+## 1) Create a GitHub App
+
+1. Go to https://github.com/settings/apps (or your org’s Developer settings) and click "New GitHub App".
+2. Fill out basic info (name, homepage URL, etc.).
+3. Under Repository permissions, set:
+   - Issues: Read and write
+   - Pull requests: Read and write
+   - Contents: Read-only
+4. Webhooks are not required for these workflows; you can leave webhook settings as default (disabled) unless you need them.
+5. Save the App and generate a Private Key (PEM). Download it.
+
+## 2) Install the App on the Repository
+
+1. From the App page, click "Install App".
+2. Choose the target organization or your user account.
+3. Select the repository where you want to enable automation (this repo), or "All repositories" if desired.
+
+## 3) Add Repository Secrets
+
+Create these secrets in the repository (Settings → Secrets and variables → Actions → New repository secret):
+
+- APP_ID: The numeric ID of your GitHub App (found on the App page)
+- APP_PRIVATE_KEY: Paste the contents of the PEM private key you downloaded
+
+Note: Keep the PEM content exactly as downloaded, including BEGIN/END headers. Multi-line secrets are supported.
+
+## 4) Validate Workflows
+
+These workflows rely on the GitHub App token via `actions/create-github-app-token@v1`:
+
+- `.github/workflows/auto-create-rfc-issues-on-push.yml`
+- `.github/workflows/assign-rfc-issues-to-agent.yml`
+- `.github/workflows/auto-spawn-copilot-agents.yml`
+- `.github/workflows/labels-sync.yml`
+- (Legacy) `.github/workflows/trigger-copilot-implementation.yml`
+
+Ensure the above workflows run in your environment with the secrets properly configured.
+
+## 5) Test the Setup
+
+- Trigger a label sync to create standard labels:
+  - Actions → "Sync Repository Labels" → Run workflow
+- Create or update an RFC doc in `docs/RFC/` on `main`:
+  - Verify an issue is created and labeled `rfc-implementation`.
+- Manually assign and spawn Copilot for a test issue:
+  - Actions → "Assign RFC Issues to Agent" → issue_numbers: the test issue number, add labels
+  - Actions → "Auto-Spawn Copilot RFC Agents" → Run workflow
+
+## 6) Copilot Coding Agent Enablement
+
+- Ensure your organization/repository has GitHub Copilot Coding Agent enabled.
+- The system cannot programmatically start a Copilot session; it prepares issues and posts detailed instructions.
+- Use the GitHub UI ("Let Copilot work on this") or Copilot Chat to start the agent if available.
+
+## Troubleshooting
+
+- If workflows fail with authentication errors, re-check APP_ID and APP_PRIVATE_KEY secrets.
+- Make sure the App is installed on the correct repository and has the listed permissions.
+- Ensure labels exist via the label sync workflow.
+- For rate-limit issues, try again after a short delay.

--- a/ruleset-skip-rfc-check.json
+++ b/ruleset-skip-rfc-check.json
@@ -1,0 +1,28 @@
+﻿{
+  "name": "Bypass reviews and Gemini when skip-rfc-check",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/heads/main"] },
+    "pull_request": {
+      "labels": { "include": ["skip-rfc-check"] }
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "required_approving_review_count": 0
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": []
+      }
+    }
+  ]
+}

--- a/trigger-copilot-rfc.ps1
+++ b/trigger-copilot-rfc.ps1
@@ -1,0 +1,136 @@
+# PowerShell script to manually trigger GitHub Copilot for RFC implementation
+
+param(
+    [Parameter(Mandatory=$true)]
+    [int]$IssueNumber,
+    
+    [Parameter(Mandatory=$false)]
+    [switch]$Force,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$Repository = ""
+)
+
+# Check if GitHub CLI is installed
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) is not installed. Please install it first: https://cli.github.com/"
+    exit 1
+}
+
+# Resolve repository if not provided
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+    if ($env:GH_REPOSITORY) {
+        $Repository = $env:GH_REPOSITORY
+    } else {
+        try {
+            $originUrl = git remote get-url origin 2>$null
+        } catch { $originUrl = $null }
+        if ($originUrl) {
+            # Support SSH and HTTPS formats
+            if ($originUrl -match 'git@[^:]+:([^/]+/[^/\.]+)') { $Repository = $Matches[1] }
+            elseif ($originUrl -match 'https?://[^/]+/([^/]+/[^/\.]+)(?:\.git)?') { $Repository = $Matches[1] }
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+    Write-Error "Repository not specified and could not be auto-detected. Provide -Repository or set GH_REPOSITORY."
+    exit 1
+}
+
+Write-Host "🚀 Triggering GitHub Copilot for RFC implementation..." -ForegroundColor Cyan
+
+try {
+    # Get issue details
+    $issueData = gh issue view $IssueNumber --repo $Repository --json labels,title,body,assignees | ConvertFrom-Json
+    
+    if (-not $issueData) {
+        Write-Error "Could not find issue #$IssueNumber in repository $Repository"
+        exit 1
+    }
+    
+    Write-Host "📋 Issue: $($issueData.title)" -ForegroundColor Green
+    
+    # Check if it's an RFC implementation issue
+    $hasRfcLabel = $issueData.labels | Where-Object { $_.name -eq "rfc-implementation" }
+    $hasAgentLabel = $issueData.labels | Where-Object { $_.name -eq "agent-assigned" }
+    $hasWorkingLabel = $issueData.labels | Where-Object { $_.name -eq "copilot-working" }
+    
+    if (-not $hasRfcLabel) {
+        Write-Warning "Issue #$IssueNumber does not have 'rfc-implementation' label"
+    }
+    
+    if (-not $hasAgentLabel) {
+        Write-Warning "Issue #$IssueNumber does not have 'agent-assigned' label"
+    }
+    
+    if ($hasWorkingLabel -and -not $Force) {
+        Write-Warning "Issue #$IssueNumber already has 'copilot-working' label. Use -Force to override."
+        exit 1
+    }
+    
+    # Extract RFC number
+    $rfcMatch = [regex]::Match($issueData.title, 'RFC(\d{3})')
+    if (-not $rfcMatch.Success) {
+        Write-Error "Could not extract RFC number from issue title: $($issueData.title)"
+        exit 1
+    }
+    
+    $rfcNumber = $rfcMatch.Groups[1].Value
+    Write-Host "🎯 RFC Number: $rfcNumber" -ForegroundColor Yellow
+    
+    # Add copilot-working label
+    Write-Host "🏷️ Adding 'copilot-working' label..." -ForegroundColor Blue
+    gh issue edit $IssueNumber --repo $Repository --add-label "copilot-working"
+    
+    # Create comprehensive implementation comment for Copilot
+    $copilotComment = @"
+@copilot Please implement RFC$rfcNumber following the project's coding standards and architecture.
+
+## 🎯 Implementation Instructions
+
+1. **Read the RFC**: Study the complete RFC specification in docs/RFC/RFC$rfcNumber-*.md
+2. **Follow Architecture**: Use Arch ECS patterns - Components are data, Systems are logic  
+3. **Use Terminal.Gui**: All UI must use Terminal.Gui v2 framework
+4. **Write Tests**: Achieve >80% test coverage with unit and integration tests
+5. **Check Acceptance Criteria**: Complete ALL checkboxes in the RFC
+6. **Create Feature Branch**: Use ``feature/rfc$rfcNumber-[description]`` naming convention
+
+## 📋 Technical Requirements
+
+- **ECS Patterns**: Components as structs, Systems inherit from ``SystemBase<World, float>``
+- **Event System**: Use ``GameEvents.RaiseXXX()`` for inter-system communication
+- **File Organization**: Follow ``src/DungeonCodingAgent.Game/[Components|Systems|UI|Core]/`` structure
+- **Testing**: Write comprehensive tests in ``tests/DungeonCodingAgent.Tests/``
+- **Code Style**: Follow existing C# conventions in the codebase
+
+## 🔗 Key Resources
+
+- **Architecture Guidelines**: See ``AGENTS.md`` and ``.github/copilot-instructions.md``
+- **RFC Document**: Complete specification is in ``docs/RFC/RFC$rfcNumber-*.md``
+- **Existing Code**: Study current patterns in the codebase
+- **Dependencies**: Terminal.Gui 2.0.0, Arch 2.0.0, xUnit for tests
+
+## ✅ Definition of Done
+
+- [ ] All RFC acceptance criteria checkboxes completed
+- [ ] Unit tests written and passing (>80% coverage)
+- [ ] Integration tests verify system works with existing code
+- [ ] Code follows project architectural patterns
+- [ ] Feature works as demonstrated in RFC
+- [ ] Pull request created with detailed description
+
+Please create a feature branch and implement this RFC completely. Comment with your progress and questions as needed.
+"@
+
+    # Post the comment
+    Write-Host "💬 Posting implementation comment to trigger Copilot..." -ForegroundColor Magenta
+    $copilotComment | gh issue comment $IssueNumber --repo $Repository --body-file -
+    
+    Write-Host "✅ Successfully triggered GitHub Copilot for issue #$IssueNumber (RFC$rfcNumber)" -ForegroundColor Green
+    Write-Host "🔗 View issue: https://github.com/$Repository/issues/$IssueNumber" -ForegroundColor Cyan
+    
+} catch {
+    Write-Error "Failed to trigger Copilot: $($_.Exception.Message)"
+    exit 1
+}

--- a/trigger-copilot-rfc.sh
+++ b/trigger-copilot-rfc.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Bash script to manually trigger GitHub Copilot for RFC implementation
+
+set -euo pipefail
+
+# Default values
+REPOSITORY=""
+FORCE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --issue|-i)
+            ISSUE_NUMBER="$2"
+            shift 2
+            ;;
+        --repo|-r)
+            REPOSITORY="$2"
+            shift 2
+            ;;
+        --force|-f)
+            FORCE=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 --issue <issue_number> [--repo <repository>] [--force]"
+            echo ""
+            echo "Options:"
+            echo "  --issue, -i    Issue number to trigger Copilot for (required)"
+            echo "  --repo, -r     Repository (default: auto-detect)"
+            echo "  --force, -f    Force trigger even if already in progress"
+            echo "  --help, -h     Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve repository if not provided
+if [[ -z "${REPOSITORY}" ]]; then
+    if [[ -n "${GH_REPOSITORY:-}" ]]; then
+        REPOSITORY="$GH_REPOSITORY"
+    else
+        originUrl=$(git remote get-url origin 2>/dev/null || true)
+        if [[ -n "$originUrl" ]]; then
+            if [[ "$originUrl" =~ git@[^:]+:([^/]+/[^/\.]+)(\.git)?$ ]]; then
+                REPOSITORY="${BASH_REMATCH[1]}"
+            elif [[ "$originUrl" =~ https?://[^/]+/([^/]+/[^/\.]+)(\.git)?$ ]]; then
+                REPOSITORY="${BASH_REMATCH[1]}"
+            fi
+        fi
+    fi
+fi
+
+# Validate required arguments
+if [[ -z "${ISSUE_NUMBER:-}" ]]; then
+    echo "❌ Error: Issue number is required"
+    echo "Usage: $0 --issue <issue_number> [--repo <repository>] [--force]"
+    exit 1
+fi
+
+if [[ -z "${REPOSITORY}" ]]; then
+    echo "❌ Error: Repository not specified and could not be auto-detected. Provide --repo or set GH_REPOSITORY."
+    exit 1
+fi
+
+# Check if GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "❌ Error: GitHub CLI (gh) is not installed"
+    echo "Please install it first: https://cli.github.com/"
+    exit 1
+fi
+
+# Check if jq is installed (required for JSON parsing)
+if ! command -v jq &> /dev/null; then
+    echo "❌ Error: 'jq' is required but not installed"
+    echo "Please install jq: https://stedolan.github.io/jq/download/"
+    exit 1
+fi
+
+echo "🚀 Triggering GitHub Copilot for RFC implementation..."
+
+# Get issue details
+echo "📋 Fetching issue #$ISSUE_NUMBER details..."
+ISSUE_DATA=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json labels,title,body,assignees)
+
+if [[ -z "$ISSUE_DATA" ]]; then
+    echo "❌ Error: Could not find issue #$ISSUE_NUMBER in repository $REPOSITORY"
+    exit 1
+fi
+
+ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
+echo "📋 Issue: $ISSUE_TITLE"
+
+# Check labels
+HAS_RFC_LABEL=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "rfc-implementation" && echo "true" || echo "false")
+HAS_AGENT_LABEL=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "agent-assigned" && echo "true" || echo "false")
+HAS_WORKING_LABEL=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | grep -q "copilot-working" && echo "true" || echo "false")
+
+if [[ "$HAS_RFC_LABEL" != "true" ]]; then
+    echo "⚠️ Warning: Issue #$ISSUE_NUMBER does not have 'rfc-implementation' label"
+fi
+
+if [[ "$HAS_AGENT_LABEL" != "true" ]]; then
+    echo "⚠️ Warning: Issue #$ISSUE_NUMBER does not have 'agent-assigned' label"
+fi
+
+if [[ "$HAS_WORKING_LABEL" == "true" && "$FORCE" != "true" ]]; then
+    echo "⚠️ Warning: Issue #$ISSUE_NUMBER already has 'copilot-working' label"
+    echo "Use --force to override"
+    exit 1
+fi
+
+# Extract RFC number
+RFC_NUMBER=$(echo "$ISSUE_TITLE" | grep -o 'RFC[0-9]\{3\}' | head -1 | sed 's/RFC//' || echo "")
+
+if [[ -z "$RFC_NUMBER" ]]; then
+    echo "❌ Error: Could not extract RFC number from issue title: $ISSUE_TITLE"
+    exit 1
+fi
+
+echo "🎯 RFC Number: $RFC_NUMBER"
+
+# Add copilot-working label
+echo "🏷️ Adding 'copilot-working' label..."
+gh issue edit "$ISSUE_NUMBER" --repo "$REPOSITORY" --add-label "copilot-working"
+
+# Create comprehensive implementation comment for Copilot
+echo "💬 Posting implementation comment to trigger Copilot..."
+
+COPILOT_COMMENT=$(cat << EOF
+@copilot Please implement RFC$RFC_NUMBER following the project's coding standards and architecture.
+
+## 🎯 Implementation Instructions
+
+1. **Read the RFC**: Study the complete RFC specification in docs/RFC/RFC$RFC_NUMBER-*.md
+2. **Follow Architecture**: Use Arch ECS patterns - Components are data, Systems are logic  
+3. **Use Terminal.Gui**: All UI must use Terminal.Gui v2 framework
+4. **Write Tests**: Achieve >80% test coverage with unit and integration tests
+5. **Check Acceptance Criteria**: Complete ALL checkboxes in the RFC
+6. **Create Feature Branch**: Use \`feature/rfc$RFC_NUMBER-[description]\` naming convention
+
+## 📋 Technical Requirements
+
+- **ECS Patterns**: Components as structs, Systems inherit from \`SystemBase<World, float>\`
+- **Event System**: Use \`GameEvents.RaiseXXX()\` for inter-system communication
+- **File Organization**: Follow \`src/DungeonCodingAgent.Game/[Components|Systems|UI|Core]/\` structure
+- **Testing**: Write comprehensive tests in \`tests/DungeonCodingAgent.Tests/\`
+- **Code Style**: Follow existing C# conventions in the codebase
+
+## 🔗 Key Resources
+
+- **Architecture Guidelines**: See \`AGENTS.md\` and \`.github/copilot-instructions.md\`
+- **RFC Document**: Complete specification is in \`docs/RFC/RFC$RFC_NUMBER-*.md\`
+- **Existing Code**: Study current patterns in the codebase
+- **Dependencies**: Terminal.Gui 2.0.0, Arch 2.0.0, xUnit for tests
+
+## ✅ Definition of Done
+
+- [ ] All RFC acceptance criteria checkboxes completed
+- [ ] Unit tests written and passing (>80% coverage)
+- [ ] Integration tests verify system works with existing code
+- [ ] Code follows project architectural patterns
+- [ ] Feature works as demonstrated in RFC
+- [ ] Pull request created with detailed description
+
+Please create a feature branch and implement this RFC completely. Comment with your progress and questions as needed.
+EOF
+)
+
+# Post the comment
+echo "$COPILOT_COMMENT" | gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body-file -
+
+echo "✅ Successfully triggered GitHub Copilot for issue #$ISSUE_NUMBER (RFC$RFC_NUMBER)"
+echo "🔗 View issue: https://github.com/$REPOSITORY/issues/$ISSUE_NUMBER"


### PR DESCRIPTION
This PR makes the repo public-ready and improves automation:\n\n- Centralized labels (adds copilot-working, agent-work)\n- Shared COPILOT_MAX_CAPACITY across workflows\n- Restrict legacy trigger workflow to manual dispatch\n- Add jq check to trigger-copilot-rfc.sh\n- Add LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md\n- Add docs/GITHUB-APP-SETUP.md and link from README\n\nAfter merge, I will run:\n- Sync Repository Labels\n- Assign RFC Issues to Agent (all)\n- Auto-Spawn Copilot RFC Agents (all, force=false)\n