### PR TITLE
fix: Enable variable substitution in status dashboard

### DIFF
--- a/.github/workflows/status-dashboard.yml
+++ b/.github/workflows/status-dashboard.yml
@@ -45,7 +45,7 @@ jobs:
           git ls-remote --heads https://github.com/${{ github.repository }}.git > /tmp/heads.txt
           BRANCHES_COPILOT=$(cat /tmp/heads.txt | grep -Ei '(copilot|feature/rfc)' | wc -l | xargs)
 
-          cat > DASHBOARD.md <<'MD'
+          cat > DASHBOARD.md <<MD
           ## 🤖 Agent Status Dashboard
 
           | Metric | Value |
@@ -62,6 +62,7 @@ jobs:
           ### Notes
           - Copilot assignee detected as: ${COPILOT_LOGIN:-<not found>}
           - This dashboard updates every 30 minutes.
+          - Generated: $(date -u)
           MD
 
           echo "done=1" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The status dashboard was showing variable names instead of actual values:
- `Total RFC issues: ${TOTAL_RFCS}` instead of actual counts
- All metrics displayed as literal variable names

## Root Cause

Quoted heredoc (`<<'MD'`) prevents bash variable substitution. The single quotes tell bash to treat the entire heredoc as literal text.

## Solution

- Changed from `<<'MD'` to `<<MD` to enable variable expansion
- Added timestamp to show when dashboard was last updated
- Variables now properly substitute with actual values

## Testing

This is a critical infrastructure fix for monitoring our RFC progress. The dashboard runs every 30 minutes and provides essential metrics for tracking implementation progress.